### PR TITLE
Example of only running CI if the diff has a JS or TS files

### DIFF
--- a/.circleci/config.old.yml
+++ b/.circleci/config.old.yml
@@ -440,7 +440,6 @@ workflows:
       - smoke-tests:
           requires:
             - build
-          when: << pipeline.parameters.run-js >>
       - unit-tests:
           requires:
             - build
@@ -453,6 +452,10 @@ workflows:
       - chromatic:
           requires:
             - examples
+  sandboxes:
+    when: << pipeline.parameters.run-js >>
+    jobs:
+      - build
       - publish:
           requires:
             - build

--- a/.circleci/config.old.yml
+++ b/.circleci/config.old.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  run-js:
+    type: boolean
+    default: false
+
 executors:
   sb_node_14_classic:
     parameters:
@@ -435,6 +440,7 @@ workflows:
       - smoke-tests:
           requires:
             - build
+          when: << pipeline.parameters.run-js >>
       - unit-tests:
           requires:
             - build

--- a/.circleci/config.old.yml
+++ b/.circleci/config.old.yml
@@ -82,7 +82,7 @@ commands:
 jobs:
   check:
     executor:
-      class: xlarge
+      class: large
       name: sb_node_14_classic
     steps:
       - git-shallow-clone/checkout_advanced:
@@ -98,7 +98,7 @@ jobs:
             git diff --exit-code
   build:
     executor:
-      class: xlarge
+      class: large
       name: sb_node_14_classic
     steps:
       - git-shallow-clone/checkout_advanced:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,25 +2,13 @@ version: 2.1
 setup: true
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.0.3
   path-filtering: circleci/path-filtering@0.1.3
-  node: circleci/node@5.0.3
 
-jobs:
+workflows:
   setup:
-    executor: continuation/default
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
-      - node/install:
-          node-version: '16.17'
+    jobs:
       - path-filtering/filter:
           name: Create dynamic jobs
           mapping: |
             .*\.[tj]s$ run-js true
           config-path: .circleci/config.old.yml
-
-workflows:
-  setup:
-    jobs:
-      - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ setup: true
 
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.0.3
-  continuation: circleci/continuation@0.1.2
+  path-filtering: circleci/path-filtering@0.1.3
   node: circleci/node@5.0.3
 
 jobs:
@@ -14,12 +14,11 @@ jobs:
           clone_options: '--depth 1 --verbose'
       - node/install:
           node-version: '16.17'
-      - run:
-          name: Generate config
-          command: |
-            node ./scripts/ci/generate.js
-      - continuation/continue:
-          configuration_path: .circleci/config.generated.yml
+      - path-filtering/filter:
+          name: Create dynamic jobs
+          mapping: |
+            .*\.[tj]s$ run-js true
+          config-path: .circleci/config.old.yml
 
 workflows:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
     jobs:
       - path-filtering/filter:
           name: Create dynamic jobs
+          config-path: .circleci/config.old.yml
+          base-revision: next
           mapping: |
             .*\.[tj]s$ run-js true
-          config-path: .circleci/config.old.yml


### PR DESCRIPTION
Not meant to merge, just an exploration of the [path-filtering](https://circleci.com/developer/orbs/orb/circleci/path-filtering) orb

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
